### PR TITLE
Removed grunt peerdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
         "mockserver-grunt": "~1",
         "nodeunit": "~0.9"
     },
-    "peerDependencies": {
-        "grunt": "~1.0"
-    },
     "keywords": [
         "mockserver",
         "client",


### PR DESCRIPTION
The grunt peerDependency is never used inside this module so can be removed.
This enables projects that don't use grunt to use the mockserver client
