### PR TITLE
Do not use protractor promise if promise manager is disabled

### DIFF
--- a/sendRequest.js
+++ b/sendRequest.js
@@ -13,7 +13,9 @@
         var http = require('http');
 
         var defer = function () {
-            var promise = (global.protractor ? protractor.promise : Q);
+            var promise = (global.protractor && protractor.promise.USE_PROMISE_MANAGER !== false) 
+                ? protractor.promise 
+                : Q;
             var deferred = promise.defer();
 
             if (deferred.fulfill && !deferred.resolve) {


### PR DESCRIPTION
The web driver control flow that protractor uses will soon be disabled - https://github.com/angular/protractor/blob/master/docs/async-await.md. There is a way to disable the promise manager now, however doing so causes an exception to be thrown because this and mockserver-node both use the protractor.promise if it is available. 

```
[14:13:37] E/launcher - Error: TypeError: Unable to create a managed promise instance: the promise manager has been disabled by the SELENIUM_PROMISE_MANAGER environment variable: undefined
    at new ManagedPromise (/home/micah/Documents/admin/node_modules/selenium-webdriver/lib/promise.js:1031:13)
    at new Deferred (/home/micah/Documents/admin/node_modules/selenium-webdriver/lib/promise.js:1408:20)
    at Object.defer (/home/micah/Documents/admin/node_modules/selenium-webdriver/lib/promise.js:1495:10)
    at defer (/home/micah/Documents/admin/node_modules/mockserver-node/index.js:21:32)
    at Object.stop_mockserver (/home/micah/Documents/admin/node_modules/mockserver-node/index.js:233:24)
```

This pull request checks if USE_PROMISE_MANAGER has been explicitly set to false, and if so will not use protractor.promise.